### PR TITLE
Update Immutable to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ const data = {
 
 // Serialization
 const json = serialize(data)
-// json == '{"x":{"__iterable":"Map","data":[["y",{"__iterable":"List","data":[1,2,3]"}]]}}'
+// json == '{"x":{"__collection":"Map","data":[["y",{"__collection":"List","data":[1,2,3]"}]]}}'
 
 // Deserialize
 const result = deserialize(json)
@@ -108,6 +108,7 @@ NOTE: When an unknown Immutable iterable type is encountered during deserializat
     - `json`: A JSON representation of data.
     - `options={}`: Deserialization options.
         - `recordTypes={}`: `immutable.Record` factories.
+        - `throwOnMissingRecordType=true`: Creates an `AnonymousRecord` for missing RecordTypes with all decoded data keys.
 
     Return value:
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "lint-fix": "tslint -c ./tslint.json --project ./tsconfig.json --fix",
     "lint": "tslint -c ./tslint.json --project ./tsconfig.json",
-    "prettier": "prettier \"src/**/*.{js,jsx,ts,tsx}\" --write",
+    "prettier": "prettier \"{src,test}/**/*.{js,jsx,ts,tsx}\" --write",
     "test": "npm run build && ava",
     "typecheck": "tsc --noEmit --listFiles false"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     }
   },
   "peerDependencies": {
-    "immutable": "3.x.x"
+    "immutable": "^4.0.0-rc.12"
   },
   "dependencies": {
     "@types/node": "^11.10.0",
@@ -33,7 +33,7 @@
   "devDependencies": {
     "ava": "^1.2.1",
     "husky": "^1.3.1",
-    "immutable": "3.8.x",
+    "immutable": "^4.0.0-rc.12",
     "lint-staged": "^8.1.5",
     "prettier": "^1.16.4",
     "tslint": "^5.13.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,4 @@ export * from './serialize';
 
 export * from './types/options';
 export * from './types/serializedData';
-export * from './types/iterableTypes';
+export * from './types/collectionTypes';

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -1,4 +1,4 @@
-import { Iterable, Record } from 'immutable';
+import { isCollection, Record } from 'immutable';
 import JSONStreamStringify from 'json-stream-stringify';
 import {
   SerializationOptions,
@@ -15,8 +15,8 @@ export function serialize(
   options: SerializationOptions = {},
 ): string | never {
   if (
-    Iterable.isIterable(data) ||
-    data instanceof Record ||
+    isCollection(data) ||
+    Record.isRecord(data) ||
     isSupportedNativeType(data)
   ) {
     const patchedData = Object.create(data);

--- a/src/types/collectionTypes.ts
+++ b/src/types/collectionTypes.ts
@@ -1,4 +1,4 @@
-export type IterableType =
+export type CollectionType =
   | 'List'
   | 'Map'
   | 'OrderedMap'

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -10,5 +10,6 @@ export interface SerializationStreamOptions {
 }
 
 export interface DeserializationOptions {
-  recordTypes?: { [recordName: string]: Record.Class };
+  recordTypes?: { [recordName: string]: ReturnType<typeof Record> };
+  throwOnMissingRecordType?: boolean;
 }

--- a/src/types/serializedData.ts
+++ b/src/types/serializedData.ts
@@ -1,7 +1,7 @@
-import { IterableType } from './iterableTypes';
+import { CollectionType } from './collectionTypes';
 
-export interface SerializedIterable {
-  __iterable: IterableType;
+export interface SerializedCollection {
+  __collection: CollectionType;
   data: any[] | Array<[string | number, any]>;
 }
 

--- a/src/utils/collections.ts
+++ b/src/utils/collections.ts
@@ -1,5 +1,5 @@
 import {
-  Iterable,
+  Collection,
   List,
   Map,
   OrderedMap,
@@ -7,11 +7,11 @@ import {
   Set,
   Stack,
 } from 'immutable';
-import { IterableType } from '../types/iterableTypes';
+import { CollectionType } from '../types/collectionTypes';
 
-export function getIterableType(
-  iterable: Iterable<string | number, any>,
-): IterableType | undefined {
+export function getCollectionType(
+  iterable: Collection<string | number, any>,
+): CollectionType | undefined {
   if (List.isList(iterable)) {
     return 'List';
   }

--- a/src/utils/getUniqueId.ts
+++ b/src/utils/getUniqueId.ts
@@ -1,0 +1,4 @@
+export function getUniqueId(prefix?: string): () => string {
+  let idCounter = 0;
+  return () => `${prefix ? `${prefix}-` : ''}${idCounter++}`;
+}

--- a/test/create-serialization-stream/_helpers.js
+++ b/test/create-serialization-stream/_helpers.js
@@ -1,54 +1,53 @@
-const assert = require('assert')
+const assert = require('assert');
 
-const JsonImmutable = require('../../lib/')
+const JsonImmutable = require('../../lib/');
 
-
-exports.testSerializationStream = function (test, data, expectedResult) {
-  const littleChunkedData = getSerializationStreamDataWithOptions(data, {})
+exports.testSerializationStream = function(test, data, expectedResult) {
+  const littleChunkedData = getSerializationStreamDataWithOptions(data, {});
   const bigChunkedData = getSerializationStreamDataWithOptions(data, {
     bigChunks: true,
-  })
+  });
 
   return littleChunkedData.then((littleChunkedData) => {
     return bigChunkedData.then((bigChunkedData) => {
       assert.equal(
         littleChunkedData,
         bigChunkedData,
-        'Little-chunked and big-chunked serialization results do not match.'
-      )
-      test.deepEqual(JSON.parse(littleChunkedData), expectedResult)
-    })
-  })
-}
+        'Little-chunked and big-chunked serialization results do not match.',
+      );
+      test.deepEqual(JSON.parse(littleChunkedData), expectedResult);
+    });
+  });
+};
 
-exports.getSerializationStreamResult = function (data, options) {
-  const littleChunkedData = getSerializationStreamDataWithOptions(data, {})
+exports.getSerializationStreamResult = function(data, options) {
+  const littleChunkedData = getSerializationStreamDataWithOptions(data, {});
   const bigChunkedData = getSerializationStreamDataWithOptions(data, {
     bigChunks: true,
-  })
+  });
 
   return littleChunkedData.then((littleChunkedData) => {
     return bigChunkedData.then((bigChunkedData) => {
       assert.equal(
         littleChunkedData,
         bigChunkedData,
-        'Little-chunked and big-chunked serialization results do not match.'
-      )
-      return JSON.parse(littleChunkedData)
-    })
-  })
-}
+        'Little-chunked and big-chunked serialization results do not match.',
+      );
+      return JSON.parse(littleChunkedData);
+    });
+  });
+};
 
 function getSerializationStreamDataWithOptions(data, options) {
   return new Promise((resolve) => {
-    const jsonStream = JsonImmutable.createSerializationStream(data, options)
-    const jsonChunks = []
+    const jsonStream = JsonImmutable.createSerializationStream(data, options);
+    const jsonChunks = [];
     jsonStream.on('data', (chunk) => {
-      jsonChunks.push(chunk)
-    })
+      jsonChunks.push(chunk);
+    });
     jsonStream.on('end', () => {
-      const json = jsonChunks.join('')
-      resolve(json)
-    })
-  })
+      const json = jsonChunks.join('');
+      resolve(json);
+    });
+  });
 }

--- a/test/create-serialization-stream/iterable.js
+++ b/test/create-serialization-stream/iterable.js
@@ -3,190 +3,190 @@ import it from 'ava';
 
 import helpers from './_helpers';
 
-it('should mark an immutable.Map as __iterable=Map', test => {
+it('should mark an immutable.Map as __collection=Map', (test) => {
   const data = immutable.Map({
     a: 5,
-    b: 6
+    b: 6,
   });
 
   const result = helpers.getSerializationStreamResult(data);
-  return result.then(result => {
-    test.is(result['__iterable'], 'Map');
+  return result.then((result) => {
+    test.is(result['__collection'], 'Map');
     test.truthy(result['data']);
     test.pass();
   });
 });
 
-it('should serialize a nested immutable.Map as a nested array of entries', test => {
+it('should serialize a nested immutable.Map as a nested array of entries', (test) => {
   const data = immutable.Map({
     a: 5,
     b: immutable.Map({
-      c: 6
-    })
+      c: 6,
+    }),
   });
 
   const result = helpers.getSerializationStreamResult(data);
-  return result.then(result => {
+  return result.then((result) => {
     test.deepEqual(result['data'], [
       ['a', 5],
       [
         'b',
         {
-          __iterable: 'Map',
-          data: [['c', 6]]
-        }
-      ]
+          __collection: 'Map',
+          data: [['c', 6]],
+        },
+      ],
     ]);
     test.pass();
   });
 });
 
-it('should serialize an immutable.Map nested in a plain object', test => {
+it('should serialize an immutable.Map nested in a plain object', (test) => {
   const data = {
     x: immutable.Map({
       a: 5,
-      b: 6
-    })
+      b: 6,
+    }),
   };
 
   const result = helpers.getSerializationStreamResult(data);
-  return result.then(result => {
+  return result.then((result) => {
     test.deepEqual(result['x']['data'], [['a', 5], ['b', 6]]);
     test.pass();
   });
 });
 
-it('should preserve immutable.Map key types', test => {
+it('should preserve immutable.Map key types', (test) => {
   let data = immutable.Map();
   data = data.set(5, 'a');
   data = data.set(6, 'b');
 
   const result = helpers.getSerializationStreamResult(data);
-  return result.then(result => {
+  return result.then((result) => {
     test.deepEqual(result['data'], [[5, 'a'], [6, 'b']]);
     test.pass();
   });
 });
 
-it('should mark an immutable.OrderedMap as __iterable=OrderedMap', test => {
+it('should mark an immutable.OrderedMap as __collection=OrderedMap', (test) => {
   const data = immutable.OrderedMap({
     a: 5,
-    b: 6
+    b: 6,
   });
 
   const result = helpers.getSerializationStreamResult(data);
-  return result.then(result => {
-    test.is(result['__iterable'], 'OrderedMap');
+  return result.then((result) => {
+    test.is(result['__collection'], 'OrderedMap');
     test.truthy(result['data']);
     test.pass();
   });
 });
 
-it('should serialize an immutable.OrderedMap as an array of entries', test => {
+it('should serialize an immutable.OrderedMap as an array of entries', (test) => {
   const data = immutable.OrderedMap({
     a: 5,
-    b: 6
+    b: 6,
   });
 
   const result = helpers.getSerializationStreamResult(data);
-  return result.then(result => {
+  return result.then((result) => {
     test.deepEqual(result['data'], [['a', 5], ['b', 6]]);
     test.pass();
   });
 });
 
-it('should serialize an immutable.Map as an array of entries', test => {
+it('should serialize an immutable.Map as an array of entries', (test) => {
   const data = immutable.Map({
     a: 5,
-    b: 6
+    b: 6,
   });
 
   const result = helpers.getSerializationStreamResult(data);
-  return result.then(result => {
+  return result.then((result) => {
     test.deepEqual(result['data'], [['a', 5], ['b', 6]]);
     test.pass();
   });
 });
 
-it('should mark an immutable.List as __iterable=List', test => {
+it('should mark an immutable.List as __collection=List', (test) => {
   const data = immutable.List.of(5, 6);
 
   const result = helpers.getSerializationStreamResult(data);
-  return result.then(result => {
-    test.is(result['__iterable'], 'List');
+  return result.then((result) => {
+    test.is(result['__collection'], 'List');
     test.truthy(result['data']);
     test.pass();
   });
 });
 
-it('should serialize an immutable.List as an array of values', test => {
+it('should serialize an immutable.List as an array of values', (test) => {
   const data = immutable.List.of(5, 6);
 
   const result = helpers.getSerializationStreamResult(data);
-  return result.then(result => {
+  return result.then((result) => {
     test.deepEqual(result['data'], [5, 6]);
     test.pass();
   });
 });
 
-it('should mark an immutable.Set as __iterable=Set', test => {
+it('should mark an immutable.Set as __collection=Set', (test) => {
   const data = immutable.Set.of(5, 6);
 
   const result = helpers.getSerializationStreamResult(data);
-  return result.then(result => {
-    test.is(result['__iterable'], 'Set');
+  return result.then((result) => {
+    test.is(result['__collection'], 'Set');
     test.truthy(result['data']);
     test.pass();
   });
 });
 
-it('should serialize an immutable.Set as an array of values', test => {
+it('should serialize an immutable.Set as an array of values', (test) => {
   const data = immutable.Set.of(5, 6);
 
   const result = helpers.getSerializationStreamResult(data);
-  return result.then(result => {
+  return result.then((result) => {
     test.deepEqual(result['data'], [5, 6]);
     test.pass();
   });
 });
 
-it('should mark an immutable.OrderedSet as __iterable=OrderedSet', test => {
+it('should mark an immutable.OrderedSet as __collection=OrderedSet', (test) => {
   const data = immutable.OrderedSet.of(5, 6);
 
   const result = helpers.getSerializationStreamResult(data);
-  return result.then(result => {
-    test.is(result['__iterable'], 'OrderedSet');
+  return result.then((result) => {
+    test.is(result['__collection'], 'OrderedSet');
     test.truthy(result['data']);
     test.pass();
   });
 });
 
-it('should serialize an immutable.OrderedSet as an array of values', test => {
+it('should serialize an immutable.OrderedSet as an array of values', (test) => {
   const data = immutable.OrderedSet.of(5, 6);
 
   const result = helpers.getSerializationStreamResult(data);
-  return result.then(result => {
+  return result.then((result) => {
     test.deepEqual(result['data'], [5, 6]);
     test.pass();
   });
 });
 
-it('should mark an immutable.Stack as __iterable=Stack', test => {
+it('should mark an immutable.Stack as __collection=Stack', (test) => {
   const data = immutable.Stack.of(5, 6);
 
   const result = helpers.getSerializationStreamResult(data);
-  return result.then(result => {
-    test.is(result['__iterable'], 'Stack');
+  return result.then((result) => {
+    test.is(result['__collection'], 'Stack');
     test.truthy(result['data']);
     test.pass();
   });
 });
 
-it('should serialize an immutable.Stack as an array of values', test => {
+it('should serialize an immutable.Stack as an array of values', (test) => {
   const data = immutable.Stack.of(5, 6);
 
   const result = helpers.getSerializationStreamResult(data);
-  return result.then(result => {
+  return result.then((result) => {
     test.deepEqual(result['data'], [5, 6]);
     test.pass();
   });

--- a/test/create-serialization-stream/plain.js
+++ b/test/create-serialization-stream/plain.js
@@ -1,50 +1,42 @@
-import it from 'ava'
+import it from 'ava';
 
-import helpers from './_helpers'
-
+import helpers from './_helpers';
 
 function testPlainSerializationStream(test, data) {
-  return helpers.testSerializationStream(test, data, data)
+  return helpers.testSerializationStream(test, data, data);
 }
 
-
-
 it('should serialize a null value', (test) => {
-  return testPlainSerializationStream(test, null)
-})
-
+  return testPlainSerializationStream(test, null);
+});
 
 it('should serialize a string value', (test) => {
-  return testPlainSerializationStream(test, 'string value')
-})
-
+  return testPlainSerializationStream(test, 'string value');
+});
 
 it('should serialize a numeric value', (test) => {
-  return testPlainSerializationStream(test, 123)
-})
-
+  return testPlainSerializationStream(test, 123);
+});
 
 it('should serialize a single-level plain object', (test) => {
   return testPlainSerializationStream(test, {
-    'a': 5,
-    'b': 6,
-  })
-})
-
+    a: 5,
+    b: 6,
+  });
+});
 
 it('should serialize a nested plain object', (test) => {
   return testPlainSerializationStream(test, {
-    'a': {
-      'b': {
-        'c': 123,
+    a: {
+      b: {
+        c: 123,
       },
     },
-  })
-})
-
+  });
+});
 
 it('should serialize an array nested in a plain object', (test) => {
   return testPlainSerializationStream(test, {
-    'a': [ 'b', 123 ],
-  })
-})
+    a: ['b', 123],
+  });
+});

--- a/test/create-serialization-stream/record.js
+++ b/test/create-serialization-stream/record.js
@@ -1,135 +1,125 @@
-import immutable from 'immutable'
-import it from 'ava'
+import immutable from 'immutable';
+import it from 'ava';
 
-import helpers from './_helpers'
+import helpers from './_helpers';
 
-
-
-it('should not mark an unnamed immutable.Record as __record', (test) => {
+it('should mark an unnamed immutable.Record as __record', (test) => {
   const SampleRecord = immutable.Record({
-    'a': 5,
-    'b': 6,
-  })
+    a: 5,
+    b: 6,
+  });
 
-  const data = SampleRecord()
-  const result = helpers.getSerializationStreamResult(data)
+  const data = SampleRecord();
+  const result = helpers.getSerializationStreamResult(data);
   return result.then((result) => {
-    test.falsy(result['__record'])
-  })
-})
-
+    test.is(result['__record'], 'Record');
+    test.truthy(result['data']);
+  });
+});
 
 it('should mark a named immutable.Record as __record=<name>', (test) => {
-  const SampleRecord = immutable.Record({
-    'a': 5,
-    'b': 6,
-  }, 'SampleRecord')
+  const SampleRecord = immutable.Record(
+    {
+      a: 5,
+      b: 6,
+    },
+    'SampleRecord',
+  );
 
-  const data = SampleRecord()
-  const result = helpers.getSerializationStreamResult(data)
+  const data = SampleRecord();
+  const result = helpers.getSerializationStreamResult(data);
   return result.then((result) => {
-    test.is(result['__record'], 'SampleRecord')
-    test.truthy(result['data'])
-  })
-})
+    test.is(result['__record'], 'SampleRecord');
+    test.truthy(result['data']);
+  });
+});
 
-
-it('should serialize an unnamed immutable.Record as a plain object',
-    (test) => {
+it('should serialize an unnamed immutable.Record as a plain object', (test) => {
   const SampleRecord = immutable.Record({
-    'a': 5,
-    'b': 6,
-  })
+    a: 5,
+    b: 6,
+  });
 
-  const data = SampleRecord()
+  const data = SampleRecord();
 
-  return helpers.testSerializationStream(test, data, {
-    'a': 5,
-    'b': 6,
-  })
-})
-
-
-it('should serialize a named immutable.Record data as a plain object',
-    (test) => {
-  const SampleRecord = immutable.Record({
-    'a': 5,
-    'b': 6,
-  }, 'SampleRecord')
-
-  const data = SampleRecord()
-  const result = helpers.getSerializationStreamResult(data)
+  const result = helpers.getSerializationStreamResult(data);
   return result.then((result) => {
     test.deepEqual(result['data'], {
-      'a': 5,
-      'b': 6,
-    })
-  })
-})
+      a: 5,
+      b: 6,
+    });
+  });
+});
 
+it('should serialize a named immutable.Record data as a plain object', (test) => {
+  const SampleRecord = immutable.Record(
+    {
+      a: 5,
+      b: 6,
+    },
+    'SampleRecord',
+  );
 
-it('should serialize nested plain objects in immutable.Record data',
-    (test) => {
-  const SampleRecord = immutable.Record({
-    'a': { 'x': 5 },
-    'b': { 'y': 6, 'z': 7 },
-  })
-
-  const data = SampleRecord()
-  const result = helpers.getSerializationStreamResult(data)
+  const data = SampleRecord();
+  const result = helpers.getSerializationStreamResult(data);
   return result.then((result) => {
-    test.deepEqual(result, {
-      'a': { 'x': 5 },
-      'b': { 'y': 6, 'z': 7 },
-    })
-  })
-})
+    test.deepEqual(result['data'], {
+      a: 5,
+      b: 6,
+    });
+  });
+});
 
+it('should serialize nested plain objects in immutable.Record data', (test) => {
+  const SampleRecord = immutable.Record({
+    a: { x: 5 },
+    b: { y: 6, z: 7 },
+  });
+
+  const data = SampleRecord();
+  const result = helpers.getSerializationStreamResult(data);
+  return result.then((result) => {
+    test.deepEqual(result['data'], {
+      a: { x: 5 },
+      b: { y: 6, z: 7 },
+    });
+  });
+});
 
 it('should serialize an immutable.Map in immutable.Record data', (test) => {
   const SampleRecord = immutable.Record({
-    'a': immutable.Map({ 'x': 5 }),
-    'b': immutable.Map({ 'y': 6, 'z': 7 },)
-  })
+    a: immutable.Map({ x: 5 }),
+    b: immutable.Map({ y: 6, z: 7 }),
+  });
 
-  const data = SampleRecord()
-  const result = helpers.getSerializationStreamResult(data)
+  const data = SampleRecord();
+  const result = helpers.getSerializationStreamResult(data);
   return result.then((result) => {
-    test.deepEqual(result, {
-      'a': {
-        '__iterable': 'Map',
-        'data': [
-          [ 'x', 5 ],
-        ],
+    test.deepEqual(result['data'], {
+      a: {
+        __collection: 'Map',
+        data: [['x', 5]],
       },
-      'b': {
-        '__iterable': 'Map',
-        'data': [
-          [ 'y', 6 ],
-          [ 'z', 7 ],
-        ],
+      b: {
+        __collection: 'Map',
+        data: [['y', 6], ['z', 7]],
       },
-    })
-  })
-})
+    });
+  });
+});
 
-
-it('should preserve key types of an immutable.Map in immutable.Record data',
-    (test) => {
-  let typedKeyedMap = immutable.Map()
-  typedKeyedMap = typedKeyedMap.set(123, 'a')
-  typedKeyedMap = typedKeyedMap.set(true, 'b')
+it('should preserve key types of an immutable.Map in immutable.Record data', (test) => {
+  let typedKeyedMap = immutable.Map();
+  typedKeyedMap = typedKeyedMap.set(123, 'a');
+  typedKeyedMap = typedKeyedMap.set(true, 'b');
 
   const SampleRecord = immutable.Record({
-    'a': typedKeyedMap
-  })
+    a: typedKeyedMap,
+  });
 
-  const data = SampleRecord()
-  const result = helpers.getSerializationStreamResult(data)
+  const data = SampleRecord();
+  const result = helpers.getSerializationStreamResult(data);
   return result.then((result) => {
-    test.deepEqual(result['a']['data'], [
-      [ 123, 'a' ],
-      [ true, 'b' ],
-    ])
-  })
-})
+    test.deepEqual(result['data']['a']['data'], [[123, 'a'], [true, 'b']]);
+  });
+});

--- a/test/deserialize/_helpers.js
+++ b/test/deserialize/_helpers.js
@@ -1,11 +1,10 @@
-const JsonImmutable = require('../../lib/')
+const JsonImmutable = require('../../lib/');
 
+exports.testDeserialization = function(test, data, expectedResult, options) {
+  const result = exports.getDeserializationResult(data, options);
+  test.deepEqual(result, expectedResult);
+};
 
-exports.testDeserialization = function (test, data, expectedResult, options) {
-  const result = exports.getDeserializationResult(data, options)
-  test.deepEqual(result, expectedResult)
-}
-
-exports.getDeserializationResult = function (data, options) {
-  return JsonImmutable.deserialize(JSON.stringify(data), options)
-}
+exports.getDeserializationResult = function(data, options) {
+  return JsonImmutable.deserialize(JSON.stringify(data), options);
+};

--- a/test/deserialize/iterable.js
+++ b/test/deserialize/iterable.js
@@ -1,158 +1,138 @@
-import immutable from 'immutable'
-import it from 'ava'
+import immutable from 'immutable';
+import it from 'ava';
 
-import helpers from './_helpers'
+import helpers from './_helpers';
 
-
-it('should deserialize an immutable.Map serialized as an array of entries',
-    (test) => {
+it('should deserialize an immutable.Map serialized as an array of entries', (test) => {
   const data = {
-    '__iterable': 'Map',
-    'data': [
-      [ 'a', 5 ],
-      [ 'b', 6 ],
-    ],
-  }
+    __collection: 'Map',
+    data: [['a', 5], ['b', 6]],
+  };
 
-  helpers.testDeserialization(test, data, immutable.Map(data['data']))
-})
+  helpers.testDeserialization(test, data, immutable.Map(data['data']));
+});
 
-
-it('should deserialize an immutable.Map serialized as a plain object',
-    (test) => {
+it('should deserialize an immutable.Map serialized as a plain object', (test) => {
   const data = {
-    '__iterable': 'Map',
-    'data': {
-      'a': 5,
-      'b': 6,
+    __collection: 'Map',
+    data: {
+      a: 5,
+      b: 6,
     },
-  }
+  };
 
-  helpers.testDeserialization(test, data, immutable.Map(data['data']))
-})
-
+  helpers.testDeserialization(test, data, immutable.Map(data['data']));
+});
 
 it('should preserve key types of an immutable.Map', (test) => {
   const data = {
-    '__iterable': 'Map',
-    'data': [
-      [ 5, 'a' ],
-      [ 6, 'b' ],
-    ],
-  }
+    __collection: 'Map',
+    data: [[5, 'a'], [6, 'b']],
+  };
 
-  helpers.testDeserialization(test, data, immutable.Map(data['data']))
-})
+  helpers.testDeserialization(test, data, immutable.Map(data['data']));
+});
 
-
-it('should deserialize an immutable.OrderedMap serialized as an array of entries',
-    (test) => {
+it('should deserialize an immutable.OrderedMap serialized as an array of entries', (test) => {
   const data = {
-    '__iterable': 'OrderedMap',
-    'data': [
-      [ 'a', 5 ],
-      [ 'b', 6 ],
-    ],
-  }
+    __collection: 'OrderedMap',
+    data: [['a', 5], ['b', 6]],
+  };
 
-  helpers.testDeserialization(test, data, immutable.OrderedMap(data['data']))
-})
+  helpers.testDeserialization(test, data, immutable.OrderedMap(data['data']));
+});
 
-
-it('should deserialize an immutable.OrderedMap serialized as a plain object',
-    (test) => {
+it('should deserialize an immutable.OrderedMap serialized as a plain object', (test) => {
   const data = {
-    '__iterable': 'OrderedMap',
-    'data': {
-      'a': 5,
-      'b': 6,
+    __collection: 'OrderedMap',
+    data: {
+      a: 5,
+      b: 6,
     },
-  }
+  };
 
-  helpers.testDeserialization(test, data, immutable.OrderedMap(data['data']))
-})
+  helpers.testDeserialization(test, data, immutable.OrderedMap(data['data']));
+});
 
-
-it('should deserialize a record of a known type nested in an immutable.Map',
-    (test) => {
-  const SampleRecord = immutable.Record({
-    'b': 1,
-    'c': 2,
-  }, 'SampleRecord')
-
+it('should deserialize a record of a known type nested in an immutable.Map', (test) => {
+  const SampleRecord = immutable.Record(
+    {
+      b: 1,
+      c: 2,
+    },
+    'SampleRecord',
+  );
 
   const data = {
-    '__iterable': 'Map',
-    'data': [
-      [ 'a', {
-        '__record': 'SampleRecord',
-        'data': {
-          'b': 5,
-          'c': 6,
-        }
-      } ],
+    __collection: 'Map',
+    data: [
+      [
+        'a',
+        {
+          __record: 'SampleRecord',
+          data: {
+            b: 5,
+            c: 6,
+          },
+        },
+      ],
     ],
-  }
+  };
 
   const expectedResult = immutable.Map({
-    'a': SampleRecord(data['data'][0][1]['data']),
-  })
+    a: SampleRecord(data['data'][0][1]['data']),
+  });
 
   helpers.testDeserialization(test, data, expectedResult, {
     recordTypes: {
-      'SampleRecord': SampleRecord,
+      SampleRecord: SampleRecord,
     },
-  })
-})
-
+  });
+});
 
 it('should deserialize an immutable.List', (test) => {
   const data = {
-    '__iterable': 'List',
-    'data': [ 5, 6 ],
-  }
+    __collection: 'List',
+    data: [5, 6],
+  };
 
-  helpers.testDeserialization(test, data, immutable.List(data['data']))
-})
-
+  helpers.testDeserialization(test, data, immutable.List(data['data']));
+});
 
 it('should deserialize an immutable.Set', (test) => {
   const data = {
-    '__iterable': 'Set',
-    'data': [ 5, 6 ],
-  }
+    __collection: 'Set',
+    data: [5, 6],
+  };
 
-  helpers.testDeserialization(test, data, immutable.Set(data['data']))
-})
-
+  helpers.testDeserialization(test, data, immutable.Set(data['data']));
+});
 
 it('should deserialize an immutable.OrderedSet', (test) => {
   const data = {
-    '__iterable': 'OrderedSet',
-    'data': [ 5, 6 ],
-  }
+    __collection: 'OrderedSet',
+    data: [5, 6],
+  };
 
-  helpers.testDeserialization(test, data, immutable.OrderedSet(data['data']))
-})
-
+  helpers.testDeserialization(test, data, immutable.OrderedSet(data['data']));
+});
 
 it('should deserialize an immutable.Stack', (test) => {
   const data = {
-    '__iterable': 'Stack',
-    'data': [ 5, 6 ],
-  }
+    __collection: 'Stack',
+    data: [5, 6],
+  };
 
-  helpers.testDeserialization(test, data, immutable.Stack(data['data']))
-})
-
+  helpers.testDeserialization(test, data, immutable.Stack(data['data']));
+});
 
 it('should not deserialize an iterable of an unknown type', (test) => {
   const data = {
-    '__iterable': 'UnknownType',
-    'data': [ 5, 6 ],
-  }
+    __collection: 'UnknownType',
+    data: [5, 6],
+  };
 
   test.throws(() => {
-    test.getDeserializationResult(data)
-  })
-})
+    test.getDeserializationResult(data);
+  });
+});

--- a/test/deserialize/native-objects.js
+++ b/test/deserialize/native-objects.js
@@ -1,25 +1,21 @@
-import it from 'ava'
+import it from 'ava';
 
-import helpers from './_helpers'
-
-
+import helpers from './_helpers';
 
 it('should deserialize a Date object', (test) => {
-  const data = { '__date': '2016-09-08T00:01:02Z' }
+  const data = { __date: '2016-09-08T00:01:02Z' };
 
-  helpers.testDeserialization(test, data, new Date(data['__date']))
-})
-
+  helpers.testDeserialization(test, data, new Date(data['__date']));
+});
 
 it('should deserialize a RegExp object', (test) => {
-  const data = { '__regexp': '/(what)?\\w+$/' }
+  const data = { __regexp: '/(what)?\\w+$/' };
 
-  helpers.testDeserialization(test, data, new RegExp('(what)?\\w+$'))
-})
-
+  helpers.testDeserialization(test, data, new RegExp('(what)?\\w+$'));
+});
 
 it('should deserialize a RegExp object with flags', (test) => {
-  const data = { '__regexp': '/(what)?\\w+$/ig' }
+  const data = { __regexp: '/(what)?\\w+$/ig' };
 
-  helpers.testDeserialization(test, data, new RegExp('(what)?\\w+$', 'ig'))
-})
+  helpers.testDeserialization(test, data, new RegExp('(what)?\\w+$', 'ig'));
+});

--- a/test/deserialize/plain.js
+++ b/test/deserialize/plain.js
@@ -1,49 +1,41 @@
-import it from 'ava'
+import it from 'ava';
 
-import helpers from './_helpers'
-
+import helpers from './_helpers';
 
 function testPlainDeserialization(test, data) {
-  return helpers.testDeserialization(test, data, data)
+  return helpers.testDeserialization(test, data, data);
 }
 
-
 it('should deserialize a null value', (test) => {
-  testPlainDeserialization(test, null)
-})
-
+  testPlainDeserialization(test, null);
+});
 
 it('should deserialize a string value', (test) => {
-  testPlainDeserialization(test, 'string value')
-})
-
+  testPlainDeserialization(test, 'string value');
+});
 
 it('should deserialize a numeric value', (test) => {
-  testPlainDeserialization(test, 123)
-})
-
+  testPlainDeserialization(test, 123);
+});
 
 it('should deserialize a single-level plain object', (test) => {
   testPlainDeserialization(test, {
-    'a': 5,
-    'b': 6,
-  })
-})
-
+    a: 5,
+    b: 6,
+  });
+});
 
 it('should deserialize a nested plain object', (test) => {
   testPlainDeserialization(test, {
-    'a': 5,
-    'b': {
-      'c': 6,
+    a: 5,
+    b: {
+      c: 6,
     },
-  })
-})
-
+  });
+});
 
 it('should deserialize an array nested in a plain object', (test) => {
   testPlainDeserialization(test, {
-    'a': [ 'b', 123 ],
-  })
-})
-
+    a: ['b', 123],
+  });
+});

--- a/test/deserialize/record.js
+++ b/test/deserialize/record.js
@@ -1,185 +1,208 @@
-import immutable from 'immutable'
-import it from 'ava'
+import immutable from 'immutable';
+import it from 'ava';
 
-import helpers from './_helpers'
-
+import helpers from './_helpers';
 
 it('should deserialize a record of a known type', (test) => {
-  const SampleRecord = immutable.Record({
-    'a': 1,
-    'b': 2,
-  }, 'SampleRecord')
+  const SampleRecord = immutable.Record(
+    {
+      a: 1,
+      b: 2,
+    },
+    'SampleRecord',
+  );
 
   const data = {
-    '__record': 'SampleRecord',
-    'data': {
-      'a': 5,
-      'b': 6,
+    __record: 'SampleRecord',
+    data: {
+      a: 5,
+      b: 6,
     },
-  }
+  };
 
   helpers.testDeserialization(test, data, SampleRecord(data['data']), {
     recordTypes: {
-      'SampleRecord': SampleRecord,
+      SampleRecord: SampleRecord,
     },
-  })
-})
-
+  });
+});
 
 it('should deserialize a record of a known class type', (test) => {
-  class SampleRecord extends immutable.Record({
-    'a': 1,
-    'b': 2,
-  }, 'SampleRecord') {
-  }
+  class SampleRecord extends immutable.Record(
+    {
+      a: 1,
+      b: 2,
+    },
+    'SampleRecord',
+  ) {}
 
   const data = {
-    '__record': 'SampleRecord',
-    'data': {
-      'a': 5,
-      'b': 6,
+    __record: 'SampleRecord',
+    data: {
+      a: 5,
+      b: 6,
     },
-  }
+  };
 
   helpers.testDeserialization(test, data, new SampleRecord(data['data']), {
     recordTypes: {
-      'SampleRecord': SampleRecord,
+      SampleRecord: SampleRecord,
     },
-  })
-})
+  });
+});
 
-
-it('should not deserialize a record of an unknown type', (test) => {
+it('should not deserialize a record of an unknown type when throwOnMissingRecordType = true', (test) => {
   const data = {
-    '__record': 'SampleRecord',
-    'data': {
-      'a': 5,
-      'b': 6,
+    __record: 'SampleRecord',
+    data: {
+      a: 5,
+      b: 6,
     },
-  }
+  };
 
   test.throws(() => {
     helpers.getDeserializationResult(data, {
       recordTypes: {},
-    })
-  })
-})
+    });
+  });
+});
 
+it('should deserialize a record of an unknown type when throwOnMissingRecordType = false', (test) => {
+  const AnonymousRecord = immutable.Record(
+    { a: undefined, b: undefined },
+    'AnonymousRecord-0',
+  );
+  const data = {
+    __record: 'UnknownRecord',
+    data: {
+      a: 5,
+      b: 6,
+    },
+  };
+
+  helpers.testDeserialization(test, data, new AnonymousRecord(data['data']), {
+    recordTypes: {},
+    throwOnMissingRecordType: false,
+  });
+});
 
 it('should deserialize nested records of known types', (test) => {
-  const RecordA = immutable.Record({
-    'a': 1,
-    'b': 2,
-  }, 'RecordA')
-  const RecordB = immutable.Record({
-    'c': 3,
-  }, 'RecordB')
+  const RecordA = immutable.Record(
+    {
+      a: 1,
+      b: 2,
+    },
+    'RecordA',
+  );
+  const RecordB = immutable.Record(
+    {
+      c: 3,
+    },
+    'RecordB',
+  );
 
   const data = {
-    '__record': 'RecordA',
-    'data': {
-      'a': 5,
-      'b': {
-        '__record': 'RecordB',
-        'data': {
-          'c': 6,
+    __record: 'RecordA',
+    data: {
+      a: 5,
+      b: {
+        __record: 'RecordB',
+        data: {
+          c: 6,
         },
       },
     },
-  }
+  };
 
   const expectedResult = RecordA({
-    'a': data['data']['a'],
-    'b': RecordB(data['data']['b']['data']),
-  })
+    a: data['data']['a'],
+    b: RecordB(data['data']['b']['data']),
+  });
 
   helpers.testDeserialization(test, data, expectedResult, {
     recordTypes: {
-      'RecordA': RecordA,
-      'RecordB': RecordB,
+      RecordA: RecordA,
+      RecordB: RecordB,
     },
-  })
-})
-
+  });
+});
 
 it('should call migrate record method when defined', (test) => {
-  test.plan(1)
-  class CustomRecord extends immutable.Record({ 'test_key': 'test-value' }) {
+  test.plan(1);
+  class CustomRecord extends immutable.Record({ test_key: 'test-value' }) {
     static migrate(values) {
-      test.pass()
-      return values
+      test.pass();
+      return values;
     }
   }
 
   const data = {
-    '__record': 'CustomRecord',
-    'data': {},
-  }
+    __record: 'CustomRecord',
+    data: {},
+  };
 
   helpers.getDeserializationResult(data, {
     recordTypes: {
-      'CustomRecord': CustomRecord,
+      CustomRecord: CustomRecord,
     },
-  })
-})
-
+  });
+});
 
 it('should pass deserialized List to migrate method', (test) => {
-  class CustomRecord extends immutable.Record({ 'test_key': 'test-value' }) {
+  class CustomRecord extends immutable.Record({ test_key: 'test-value' }) {
     static migrate(values) {
-      test.true(immutable.List.isList(values['test_key']))
-      return values
+      test.true(immutable.List.isList(values['test_key']));
+      return values;
     }
   }
 
   const data = {
-    '__record': 'CustomRecord',
-    'data': {
-      "test_key": {
-        "__iterable": "List",
-        "data": ['a', 'b', 'c']
+    __record: 'CustomRecord',
+    data: {
+      test_key: {
+        __collection: 'List',
+        data: ['a', 'b', 'c'],
       },
     },
-  }
+  };
 
   helpers.getDeserializationResult(data, {
     recordTypes: {
-      'CustomRecord': CustomRecord,
+      CustomRecord: CustomRecord,
     },
-  })
-})
-
+  });
+});
 
 it('should use the result of the migrate method', (test) => {
-  class CustomRecord extends immutable.Record({ 'test_key': 'test-value' }) {
+  class CustomRecord extends immutable.Record({ test_key: 'test-value' }) {
     static migrate(values) {
       if (immutable.List.isList(values['test_key'])) {
         return {
           test_key: values['test_key'].join('-'),
-        }
+        };
       }
 
-      return values
+      return values;
     }
   }
 
   const data = {
-    '__record': 'CustomRecord',
-    'data': {
-      "test_key": {
-        "__iterable": "List",
-        "data": ['a', 'b', 'c']
+    __record: 'CustomRecord',
+    data: {
+      test_key: {
+        __collection: 'List',
+        data: ['a', 'b', 'c'],
       },
     },
-  }
+  };
 
   const expectedResult = new CustomRecord({
-    'test_key': 'a-b-c',
-  })
+    test_key: 'a-b-c',
+  });
 
   helpers.testDeserialization(test, data, expectedResult, {
     recordTypes: {
-      'CustomRecord': CustomRecord,
+      CustomRecord: CustomRecord,
     },
-  })
-})
+  });
+});

--- a/test/serialize/_helpers.js
+++ b/test/serialize/_helpers.js
@@ -1,12 +1,11 @@
-const JsonImmutable = require('../../lib/')
+const JsonImmutable = require('../../lib/');
 
+exports.testSerialization = function(test, data, expectedResult) {
+  const result = exports.getSerializationResult(data);
+  test.deepEqual(result, expectedResult);
+};
 
-exports.testSerialization = function (test, data, expectedResult) {
-  const result = exports.getSerializationResult(data)
-  test.deepEqual(result, expectedResult)
-}
-
-exports.getSerializationResult = function (data) {
-  const json = JsonImmutable.serialize(data)
-  return JSON.parse(json)
-}
+exports.getSerializationResult = function(data) {
+  const json = JsonImmutable.serialize(data);
+  return JSON.parse(json);
+};

--- a/test/serialize/iterable.js
+++ b/test/serialize/iterable.js
@@ -1,176 +1,148 @@
-import immutable from 'immutable'
-import it from 'ava'
+import immutable from 'immutable';
+import it from 'ava';
 
-import helpers from './_helpers'
+import helpers from './_helpers';
 
-
-
-it('should mark an immutable.Map as __iterable=Map', (test) => {
+it('should mark an immutable.Map as __collection=Map', (test) => {
   const data = immutable.Map({
-    'a': 5,
-    'b': 6,
-  })
+    a: 5,
+    b: 6,
+  });
 
-  const result = helpers.getSerializationResult(data)
-  test.is(result['__iterable'], 'Map')
-  test.truthy(result['data'])
-})
-
+  const result = helpers.getSerializationResult(data);
+  test.is(result['__collection'], 'Map');
+  test.truthy(result['data']);
+});
 
 it('should serialize an immutable.Map as an array of entries', (test) => {
   const data = immutable.Map({
-    'a': 5,
-    'b': 6,
-  })
+    a: 5,
+    b: 6,
+  });
 
-  const result = helpers.getSerializationResult(data)
-  test.deepEqual(result['data'], [
-    [ 'a', 5 ],
-    [ 'b', 6 ],
-  ])
-})
+  const result = helpers.getSerializationResult(data);
+  test.deepEqual(result['data'], [['a', 5], ['b', 6]]);
+});
 
-
-it('should serialize a nested immutable.Map as a nested array of entries',
-    (test) => {
+it('should serialize a nested immutable.Map as a nested array of entries', (test) => {
   const data = immutable.Map({
-    'a': 5,
-    'b': immutable.Map({
-      'c': 6,
+    a: 5,
+    b: immutable.Map({
+      c: 6,
     }),
-  })
+  });
 
-  const result = helpers.getSerializationResult(data)
+  const result = helpers.getSerializationResult(data);
   test.deepEqual(result['data'], [
-    [ 'a', 5 ],
-    [ 'b', {
-      '__iterable': 'Map',
-      'data': [
-        [ 'c', 6 ],
-      ],
-    } ],
-  ])
-})
-
+    ['a', 5],
+    [
+      'b',
+      {
+        __collection: 'Map',
+        data: [['c', 6]],
+      },
+    ],
+  ]);
+});
 
 it('should serialize an immutable.Map nested in a plain object', (test) => {
   const data = {
-    'x': immutable.Map({
-      'a': 5,
-      'b': 6,
+    x: immutable.Map({
+      a: 5,
+      b: 6,
     }),
-  }
+  };
 
-  const result = helpers.getSerializationResult(data)
-  test.deepEqual(result['x']['data'], [
-    [ 'a', 5 ],
-    [ 'b', 6 ],
-  ])
-})
-
+  const result = helpers.getSerializationResult(data);
+  test.deepEqual(result['x']['data'], [['a', 5], ['b', 6]]);
+});
 
 it('should preserve immutable.Map key types', (test) => {
-  let data = immutable.Map()
-  data = data.set(5, 'a')
-  data = data.set(6, 'b')
+  let data = immutable.Map();
+  data = data.set(5, 'a');
+  data = data.set(6, 'b');
 
-  const result = helpers.getSerializationResult(data)
-  test.deepEqual(result['data'], [
-    [ 5, 'a' ],
-    [ 6, 'b' ],
-  ])
-})
+  const result = helpers.getSerializationResult(data);
+  test.deepEqual(result['data'], [[5, 'a'], [6, 'b']]);
+});
 
-
-it('should mark an immutable.OrderedMap as __iterable=OrderedMap', (test) => {
+it('should mark an immutable.OrderedMap as __collection=OrderedMap', (test) => {
   const data = immutable.OrderedMap({
-    'a': 5,
-    'b': 6,
-  })
+    a: 5,
+    b: 6,
+  });
 
-  const result = helpers.getSerializationResult(data)
-  test.is(result['__iterable'], 'OrderedMap')
-  test.truthy(result['data'])
-})
-
+  const result = helpers.getSerializationResult(data);
+  test.is(result['__collection'], 'OrderedMap');
+  test.truthy(result['data']);
+});
 
 it('should serialize an immutable.OrderedMap as an array of entries', (test) => {
   const data = immutable.OrderedMap({
-    'a': 5,
-    'b': 6,
-  })
+    a: 5,
+    b: 6,
+  });
 
-  const result = helpers.getSerializationResult(data)
-  test.deepEqual(result['data'], [
-    [ 'a', 5 ],
-    [ 'b', 6 ],
-  ])
-})
+  const result = helpers.getSerializationResult(data);
+  test.deepEqual(result['data'], [['a', 5], ['b', 6]]);
+});
 
-it('should mark an immutable.List as __iterable=List', (test) => {
-  const data = immutable.List.of(5, 6)
+it('should mark an immutable.List as __collection=List', (test) => {
+  const data = immutable.List.of(5, 6);
 
-  const result = helpers.getSerializationResult(data)
-  test.is(result['__iterable'], 'List')
-  test.truthy(result['data'])
-})
-
+  const result = helpers.getSerializationResult(data);
+  test.is(result['__collection'], 'List');
+  test.truthy(result['data']);
+});
 
 it('should serialize an immutable.List as an array of values', (test) => {
-  const data = immutable.List.of(5, 6)
+  const data = immutable.List.of(5, 6);
 
-  const result = helpers.getSerializationResult(data)
-  test.deepEqual(result['data'], [ 5, 6 ])
-})
+  const result = helpers.getSerializationResult(data);
+  test.deepEqual(result['data'], [5, 6]);
+});
 
+it('should mark an immutable.Set as __collection=Set', (test) => {
+  const data = immutable.Set.of(5, 6);
 
-it('should mark an immutable.Set as __iterable=Set', (test) => {
-  const data = immutable.Set.of(5, 6)
-
-  const result = helpers.getSerializationResult(data)
-  test.is(result['__iterable'], 'Set')
-  test.truthy(result['data'])
-})
-
+  const result = helpers.getSerializationResult(data);
+  test.is(result['__collection'], 'Set');
+  test.truthy(result['data']);
+});
 
 it('should serialize an immutable.Set as an array of values', (test) => {
-  const data = immutable.Set.of(5, 6)
+  const data = immutable.Set.of(5, 6);
 
-  const result = helpers.getSerializationResult(data)
-  test.deepEqual(result['data'], [ 5, 6 ])
-})
+  const result = helpers.getSerializationResult(data);
+  test.deepEqual(result['data'], [5, 6]);
+});
 
+it('should mark an immutable.OrderedSet as __collection=OrderedSet', (test) => {
+  const data = immutable.OrderedSet.of(5, 6);
 
-it('should mark an immutable.OrderedSet as __iterable=OrderedSet', (test) => {
-  const data = immutable.OrderedSet.of(5, 6)
-
-  const result = helpers.getSerializationResult(data)
-  test.is(result['__iterable'], 'OrderedSet')
-  test.truthy(result['data'])
-})
-
+  const result = helpers.getSerializationResult(data);
+  test.is(result['__collection'], 'OrderedSet');
+  test.truthy(result['data']);
+});
 
 it('should serialize an immutable.OrderedSet as an array of values', (test) => {
-  const data = immutable.OrderedSet.of(5, 6)
+  const data = immutable.OrderedSet.of(5, 6);
 
-  const result = helpers.getSerializationResult(data)
-  test.deepEqual(result['data'], [ 5, 6 ])
-})
+  const result = helpers.getSerializationResult(data);
+  test.deepEqual(result['data'], [5, 6]);
+});
 
+it('should mark an immutable.Stack as __collection=Stack', (test) => {
+  const data = immutable.Stack.of(5, 6);
 
-it('should mark an immutable.Stack as __iterable=Stack', (test) => {
-  const data = immutable.Stack.of(5, 6)
-
-  const result = helpers.getSerializationResult(data)
-  test.is(result['__iterable'], 'Stack')
-  test.truthy(result['data'])
-})
-
+  const result = helpers.getSerializationResult(data);
+  test.is(result['__collection'], 'Stack');
+  test.truthy(result['data']);
+});
 
 it('should serialize an immutable.Stack as an array of values', (test) => {
-  const data = immutable.Stack.of(5, 6)
+  const data = immutable.Stack.of(5, 6);
 
-  const result = helpers.getSerializationResult(data)
-  test.deepEqual(result['data'], [ 5, 6 ])
-})
-
+  const result = helpers.getSerializationResult(data);
+  test.deepEqual(result['data'], [5, 6]);
+});

--- a/test/serialize/native-objects.js
+++ b/test/serialize/native-objects.js
@@ -1,28 +1,24 @@
-import it from 'ava'
+import it from 'ava';
 
-import helpers from './_helpers'
-
-
+import helpers from './_helpers';
 
 it('should serialize a Date object', (test) => {
-  const date = new Date('2016-09-08')
-  const result = helpers.getSerializationResult(date)
+  const date = new Date('2016-09-08');
+  const result = helpers.getSerializationResult(date);
 
-  test.is(result['__date'], date.toISOString())
-})
-
+  test.is(result['__date'], date.toISOString());
+});
 
 it('should serialize a RegExp object', (test) => {
-  const regexp = new RegExp('(what)?\\w+$')
-  const result = helpers.getSerializationResult(regexp)
+  const regexp = new RegExp('(what)?\\w+$');
+  const result = helpers.getSerializationResult(regexp);
 
-  test.is(result['__regexp'], regexp.toString())
-})
-
+  test.is(result['__regexp'], regexp.toString());
+});
 
 it('should serialize a RegExp object with flags', (test) => {
-  const regexp = new RegExp('(what)?\\w+$', 'ig')
-  const result = helpers.getSerializationResult(regexp)
+  const regexp = new RegExp('(what)?\\w+$', 'ig');
+  const result = helpers.getSerializationResult(regexp);
 
-  test.is(result['__regexp'], regexp.toString())
-})
+  test.is(result['__regexp'], regexp.toString());
+});

--- a/test/serialize/plain.js
+++ b/test/serialize/plain.js
@@ -1,50 +1,42 @@
-import it from 'ava'
+import it from 'ava';
 
-import helpers from './_helpers'
-
+import helpers from './_helpers';
 
 function testPlainSerialization(test, data) {
-  return helpers.testSerialization(test, data, data)
+  return helpers.testSerialization(test, data, data);
 }
 
-
-
 it('should serialize a null value', (test) => {
-  testPlainSerialization(test, null)
-})
-
+  testPlainSerialization(test, null);
+});
 
 it('should serialize a string value', (test) => {
-  testPlainSerialization(test, 'string value')
-})
-
+  testPlainSerialization(test, 'string value');
+});
 
 it('should serialize a numeric value', (test) => {
-  testPlainSerialization(test, 123)
-})
-
+  testPlainSerialization(test, 123);
+});
 
 it('should serialize a single-level plain object', (test) => {
   testPlainSerialization(test, {
-    'a': 5,
-    'b': 6,
-  })
-})
-
+    a: 5,
+    b: 6,
+  });
+});
 
 it('should serialize a nested plain object', (test) => {
   testPlainSerialization(test, {
-    'a': {
-      'b': {
-        'c': 123,
+    a: {
+      b: {
+        c: 123,
       },
     },
-  })
-})
-
+  });
+});
 
 it('should serialize an array nested in a plain object', (test) => {
   testPlainSerialization(test, {
-    'a': [ 'b', 123 ],
-  })
-})
+    a: ['b', 123],
+  });
+});

--- a/test/serialize/record.js
+++ b/test/serialize/record.js
@@ -1,129 +1,117 @@
-import immutable from 'immutable'
-import it from 'ava'
+import immutable from 'immutable';
+import it from 'ava';
 
-import helpers from './_helpers'
+import helpers from './_helpers';
 
-
-
-it('should not mark an unnamed immutable.Record as __record', (test) => {
+it('should serialize an unnamed immutable.Record as __record', (test) => {
   const SampleRecord = immutable.Record({
-    'a': 5,
-    'b': 6,
-  })
+    a: 5,
+    b: 6,
+  });
 
-  const data = SampleRecord()
-  const result = helpers.getSerializationResult(data)
+  const data = SampleRecord();
+  const result = helpers.getSerializationResult(data);
 
-  test.falsy(result['__record'])
-})
-
+  test.is(result['__record'], 'Record');
+  test.truthy(result['data']);
+});
 
 it('should mark a named immutable.Record as __record=<name>', (test) => {
+  const SampleRecord = immutable.Record(
+    {
+      a: 5,
+      b: 6,
+    },
+    'SampleRecord',
+  );
+
+  const data = SampleRecord();
+  const result = helpers.getSerializationResult(data);
+
+  test.is(result['__record'], 'SampleRecord');
+  test.truthy(result['data']);
+});
+
+it('should serialize an unnamed immutable.Record as a record', (test) => {
   const SampleRecord = immutable.Record({
-    'a': 5,
-    'b': 6,
-  }, 'SampleRecord')
+    a: 5,
+    b: 6,
+  });
 
-  const data = SampleRecord()
-  const result = helpers.getSerializationResult(data)
-
-  test.is(result['__record'], 'SampleRecord')
-  test.truthy(result['data'])
-})
-
-
-it('should serialize an unnamed immutable.Record as a plain object',
-    (test) => {
-  const SampleRecord = immutable.Record({
-    'a': 5,
-    'b': 6,
-  })
-
-  const data = SampleRecord()
-
-  helpers.testSerialization(test, data, {
-    'a': 5,
-    'b': 6,
-  })
-})
-
-
-it('should serialize a named immutable.Record data as a plain object',
-    (test) => {
-  const SampleRecord = immutable.Record({
-    'a': 5,
-    'b': 6,
-  }, 'SampleRecord')
-
-  const data = SampleRecord()
-  const result = helpers.getSerializationResult(data)
+  const data = SampleRecord();
+  const result = helpers.getSerializationResult(data);
 
   test.deepEqual(result['data'], {
-    'a': 5,
-    'b': 6,
-  })
-})
+    a: 5,
+    b: 6,
+  });
+});
 
+it('should serialize a named immutable.Record data as a plain object', (test) => {
+  const SampleRecord = immutable.Record(
+    {
+      a: 5,
+      b: 6,
+    },
+    'SampleRecord',
+  );
 
-it('should serialize nested plain objects in immutable.Record data',
-    (test) => {
+  const data = SampleRecord();
+  const result = helpers.getSerializationResult(data);
+
+  test.deepEqual(result['data'], {
+    a: 5,
+    b: 6,
+  });
+});
+
+it('should serialize nested plain objects in immutable.Record data', (test) => {
   const SampleRecord = immutable.Record({
-    'a': { 'x': 5 },
-    'b': { 'y': 6, 'z': 7 },
-  })
+    a: { x: 5 },
+    b: { y: 6, z: 7 },
+  });
 
-  const data = SampleRecord()
-  const result = helpers.getSerializationResult(data)
+  const data = SampleRecord();
+  const result = helpers.getSerializationResult(data);
 
-  test.deepEqual(result, {
-    'a': { 'x': 5 },
-    'b': { 'y': 6, 'z': 7 },
-  })
-})
-
+  test.deepEqual(result['data'], {
+    a: { x: 5 },
+    b: { y: 6, z: 7 },
+  });
+});
 
 it('should serialize an immutable.Map in immutable.Record data', (test) => {
   const SampleRecord = immutable.Record({
-    'a': immutable.Map({ 'x': 5 }),
-    'b': immutable.Map({ 'y': 6, 'z': 7 },)
-  })
+    a: immutable.Map({ x: 5 }),
+    b: immutable.Map({ y: 6, z: 7 }),
+  });
 
-  const data = SampleRecord()
-  const result = helpers.getSerializationResult(data)
+  const data = SampleRecord();
+  const result = helpers.getSerializationResult(data);
 
-  test.deepEqual(result, {
-    'a': {
-      '__iterable': 'Map',
-      'data': [
-        [ 'x', 5 ],
-      ],
+  test.deepEqual(result['data'], {
+    a: {
+      __collection: 'Map',
+      data: [['x', 5]],
     },
-    'b': {
-      '__iterable': 'Map',
-      'data': [
-        [ 'y', 6 ],
-        [ 'z', 7 ],
-      ],
+    b: {
+      __collection: 'Map',
+      data: [['y', 6], ['z', 7]],
     },
-  })
-})
+  });
+});
 
-
-it('should preserve key types of an immutable.Map in immutable.Record data',
-    (test) => {
-  let typedKeyedMap = immutable.Map()
-  typedKeyedMap = typedKeyedMap.set(123, 'a')
-  typedKeyedMap = typedKeyedMap.set(true, 'b')
+it('should preserve key types of an immutable.Map in immutable.Record data', (test) => {
+  let typedKeyedMap = immutable.Map();
+  typedKeyedMap = typedKeyedMap.set(123, 'a');
+  typedKeyedMap = typedKeyedMap.set(true, 'b');
 
   const SampleRecord = immutable.Record({
-    'a': typedKeyedMap
-  })
+    a: typedKeyedMap,
+  });
 
-  const data = SampleRecord()
-  const result = helpers.getSerializationResult(data)
+  const data = SampleRecord();
+  const result = helpers.getSerializationResult(data);
 
-  test.deepEqual(result['a']['data'], [
-    [ 123, 'a' ],
-    [ true, 'b' ],
-  ])
-})
+  test.deepEqual(result['data']['a']['data'], [[123, 'a'], [true, 'b']]);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1626,9 +1626,10 @@ ignore@^3.3.5:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
   integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
 
-immutable@3.8.x:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.1.tgz#200807f11ab0f72710ea485542de088075f68cd2"
+immutable@^4.0.0-rc.12:
+  version "4.0.0-rc.12"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.12.tgz#ca59a7e4c19ae8d9bf74a97bdf0f6e2f2a5d0217"
+  integrity sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A==
 
 import-fresh@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description

Updates `immutable` to the latest version and adds an option for `AnonymousRecords` when the recordType is not found.

## Changes
- Update `Iterable.isIterable` to the new `isCollection` method for determining if something is an immutable Collection (Map, Set, List, OrderedSet, OrderedMap, Stack)
- Update `instanceof Record` to `Record.isRecord` for checking if something is a Record
- Remove `record.toMap()` and use `record.toSeq()` to iterate through key/value pairs
- Add an option for `throwOnMissingRecordType` which defaults to `true`. When `false`, this option will enable the creation of AnonymousRecords that contain all of the data keys found in the initially decodedData.
- Addressed @idolize comments to use a map instead of switch cases for encoding and decoding data